### PR TITLE
make the 1.1.0 hack work in 1.1.1 too

### DIFF
--- a/frontend/plugin_init.rb
+++ b/frontend/plugin_init.rb
@@ -24,6 +24,6 @@ Rails.application.config.after_initialize do
 
   # Temporary workaround to get multiple menu items.
   unless Plugins.repository_menu_items.include?('container_profiles')
-    Plugins.repository_menu_items << 'container_profiles'
+    Plugins.instance_variable_get(:@config)[:repository_menu_items] << 'container_profiles'
   end
 end


### PR DESCRIPTION
So I was walking some Yalies through the install process on their local machines and suggested they go ahead and use the 1.1.1 release candidate, not realizing the temporary menu workaround would break. So, this is just to avoid further confusion until the workaround is removed.
