### PR TITLE
[Delivers #92615858] Extend EAD import/export to handle container things

### DIFF
--- a/backend/model/ead_model_ext.rb
+++ b/backend/model/ead_model_ext.rb
@@ -1,0 +1,3 @@
+class EADModel
+  include ResolveChildContainersForExport
+end

--- a/backend/model/ead_serializer_ext.rb
+++ b/backend/model/ead_serializer_ext.rb
@@ -1,0 +1,3 @@
+class EADSerializer < ASpaceExport::Serializer
+  include SerializeExtraContainerValues
+end

--- a/backend/model/mixins/converter_extra_container_values.rb
+++ b/backend/model/mixins/converter_extra_container_values.rb
@@ -1,0 +1,66 @@
+module ConverterExtraContainerValues
+
+
+  def self.included(base)
+    base.extend(ClassMethods)
+
+    base.class_eval do
+      self.singleton_class.send(:alias_method, :configure_pre_manage_containers, :configure)
+      def self.configure
+        configure_pre_manage_containers
+
+        managed_containers_configure
+      end
+    end
+  end
+
+
+  module ClassMethods
+    def managed_containers_configure
+      with 'container' do
+        @containers ||= {}
+
+        # we've found that the container has a parent att and the parent is in
+        # our queue
+        if att("parent") && @containers[att('parent')]
+          cont = @containers[att('parent')]
+
+        else
+          instance_label = att("label") ? att("label").downcase : 'mixed_materials'
+
+          if instance_label =~ /(.*)\s\[([0-9]+)\]$/
+            instance_label = $1
+            barcode = $2
+          end
+
+          make :instance, {
+            :instance_type => instance_label
+          } do |instance|
+            set ancestor(:resource, :archival_object), :instances, instance
+          end
+
+          inst = context_obj
+
+          make :container do |cont|
+            set inst, :container, cont
+          end
+
+          cont =  inst.container
+          cont['barcode_1'] = barcode if barcode
+        end
+
+        # now we fill it in
+        (1..3).to_a.each do |i|
+          next unless cont["type_#{i}"].nil?
+          cont["type_#{i}"] = att('type')
+          cont["indicator_#{i}"] = format_content( inner_xml )
+          break
+        end
+        #store it here incase we find it has a parent
+        @containers[att("id")] = cont
+
+      end
+    end
+  end
+
+end

--- a/backend/model/mixins/converter_extra_container_values.rb
+++ b/backend/model/mixins/converter_extra_container_values.rb
@@ -47,6 +47,7 @@ module ConverterExtraContainerValues
 
           cont =  inst.container
           cont['barcode_1'] = barcode if barcode
+          cont['container_profile_key'] = att("altrender")
         end
 
         # now we fill it in

--- a/backend/model/mixins/ead_converter_ext.rb
+++ b/backend/model/mixins/ead_converter_ext.rb
@@ -1,0 +1,3 @@
+class EADConverter < Converter
+  include ConverterExtraContainerValues
+end

--- a/backend/model/mixins/export_helpers_ext.rb
+++ b/backend/model/mixins/export_helpers_ext.rb
@@ -1,0 +1,15 @@
+module ExportHelpers
+
+  def generate_ead(id, include_unpublished, include_daos, use_numbered_c_tags)
+    obj = resolve_references(Resource.to_jsonmodel(id), ['repository', 'linked_agents', 'subjects', 'tree', 'digital_object', 'top_container::container_profile'])
+    opts = {
+      :include_unpublished => include_unpublished,
+      :include_daos => include_daos,
+      :use_numbered_c_tags => use_numbered_c_tags
+    }
+
+    ead = ASpaceExport.model(:ead).from_resource(JSONModel(:resource).new(obj), opts)
+    ASpaceExport::stream(ead)
+  end
+
+end

--- a/backend/model/mixins/resolve_child_containers_for_export.rb
+++ b/backend/model/mixins/resolve_child_containers_for_export.rb
@@ -1,0 +1,22 @@
+module ResolveChildContainersForExport
+
+  def self.included(base)
+    base.class_eval do
+      child_class = base.instance_variable_get(:@ao)
+      child_class.class_eval do
+        def initialize(tree, repo_id)
+          @repo_id = repo_id
+          # @tree = tree
+          @children = tree ? tree['children'] : []
+          @child_class = self.class
+          @json = nil
+          RequestContext.open(:repo_id => repo_id) do
+            rec = URIResolver.resolve_references(ArchivalObject.to_jsonmodel(tree['id']), ['subjects', 'linked_agents', 'digital_object', 'top_container::container_profile'], {'ASPACE_REENTRANT' => false})
+            @json = JSONModel::JSONModel(:archival_object).new(rec)
+          end
+        end
+      end
+    end
+  end
+
+end

--- a/backend/model/mixins/serialize_extra_container_values.rb
+++ b/backend/model/mixins/serialize_extra_container_values.rb
@@ -29,6 +29,12 @@ module SerializeExtraContainerValues
           atts[:label] << " [#{inst['container']['barcode_1']}]"
         end
       end
+
+      container_profile = inst['sub_container']['top_container']['_resolved']['container_profile']['_resolved'] rescue nil
+      if container_profile
+        atts[:altrender] = container_profile['url'] || container_profile['name']
+      end
+
       xml.container(atts) {
         sanitize_mixed_content(text, xml, fragments)
       }

--- a/backend/model/mixins/serialize_extra_container_values.rb
+++ b/backend/model/mixins/serialize_extra_container_values.rb
@@ -1,0 +1,38 @@
+module SerializeExtraContainerValues
+
+
+  def self.included(base)
+    base.class_eval do
+      def serialize_container(inst, xml, fragments)
+        manage_containers_serialize_container(inst, xml, fragments)
+      end
+    end
+  end
+
+
+  def manage_containers_serialize_container(inst, xml, fragments)
+    @parent_id = nil
+    (1..3).each do |n|
+      atts = {}
+      next unless inst['container'].has_key?("type_#{n}") && inst['container'].has_key?("indicator_#{n}")
+      @container_id = prefix_id(SecureRandom.hex)
+
+      atts[:parent] = @parent_id unless @parent_id.nil?
+      atts[:id] = @container_id
+      @parent_id = @container_id
+
+      atts[:type] = inst['container']["type_#{n}"]
+      text = inst['container']["indicator_#{n}"]
+      if n == 1 && inst['instance_type']
+        atts[:label] = I18n.t("enumerations.instance_instance_type.#{inst['instance_type']}", :default => inst['instance_type'])
+        if inst['container']['barcode_1']
+          atts[:label] << " [#{inst['container']['barcode_1']}]"
+        end
+      end
+      xml.container(atts) {
+        sanitize_mixed_content(text, xml, fragments)
+      }
+    end
+  end
+
+end

--- a/schemas/container_ext.rb
+++ b/schemas/container_ext.rb
@@ -1,0 +1,3 @@
+{
+  "container_profile_key" => {"type" => "string"}
+}


### PR DESCRIPTION
Implement these rules in the plugin EAD converter/serializer:

- *Include top_container barcodes as part of &lt;container/&gt; in EAD export (use the label attribute for barcodes)*

 We extend `EADSerializer` with a new mixin `SerializeExtraContainerValues` that appends the barcode to the container label attribute surrounded by brackets e.g. "Audio [1112233]" where "Audio" is the instance type.

- *Use barcodes in &lt;container/&gt; to map top_containers as part of EAD import*

 We extend `EADConverter` with a new mixin `ConverterExtraContainerValues` that parses out the barcode (within the brackets of the label attribute) and set this on the container so it will be mapped to a top container.

- *Include top_container container profile nicknames (or URL, if present) as part of &lt;container/&gt; in EAD export (altrender would work for EAD 2002)*

 `SerializeExtraContainerValues` also includes the top container's profile URL or name (prioritise URL) for the EAD container's altrender attribute.

- *Use altrender in &lt;container/&gt; to map matches to existing container profiles as part of EAD import (but never create container profiles!!! Just map by the distinct container profile name or URL)*

 `ConverterExtraContainerValues` also grabs the altrender attribute and stores this on a temporary container JSONModel field `container_profile_key`.  This field is passed to the compatibility layer which now looks for the presence of this field and attempts to find and link to a matching Container Profile when creating a new top container.
 